### PR TITLE
fix: rename jwt_opts to avoid actual env var clash with new pydantic …

### DIFF
--- a/src/regtech_api_commons/oauth2/config.py
+++ b/src/regtech_api_commons/oauth2/config.py
@@ -18,7 +18,7 @@ class KeycloakSettings(BaseSettings):
     kc_admin_client_id: str
     kc_admin_client_secret: SecretStr
     kc_realm_url: HttpUrl
-    jwt_opts: Dict[str, bool | int] = {}
+    _jwt_opts: Dict[str, bool | int] = {}
 
     model_config = SettingsConfigDict(extra="allow")
     _jwt_opts_prefix: str = ""
@@ -40,7 +40,7 @@ class KeycloakSettings(BaseSettings):
         so we're merging settings.model_extra with environment variables.
         """
         jwt_opts_adapter = TypeAdapter(int | bool)
-        self.jwt_opts = {
+        self._jwt_opts = {
             **self.parse_jwt_vars(jwt_opts_adapter, self.model_extra.items()),
             **self.parse_jwt_vars(jwt_opts_adapter, os.environ.items()),
         }

--- a/src/regtech_api_commons/oauth2/oauth2_admin.py
+++ b/src/regtech_api_commons/oauth2/oauth2_admin.py
@@ -34,7 +34,7 @@ class OAuth2Admin:
                 key=self._get_keys(),
                 issuer=self._kc_settings.kc_realm_url.unicode_string(),
                 audience=self._kc_settings.auth_client,
-                options=self._kc_settings.jwt_opts,
+                options=self._kc_settings._jwt_opts,
             )
         except jose.ExpiredSignatureError:
             pass

--- a/tests/oauth2/test_config.py
+++ b/tests/oauth2/test_config.py
@@ -9,7 +9,7 @@ def test_jwt_opts_valid_values():
         "jwt_opts_test3": "12",
     }
     kc_settings = KeycloakSettings(**mock_config)
-    assert kc_settings.jwt_opts == {"test1": True, "test2": True, "test3": 12}
+    assert kc_settings._jwt_opts == {"test1": True, "test2": True, "test3": 12}
 
 
 def test_jwt_opts_invalid_values():

--- a/tests/oauth2/test_oauth2_admin.py
+++ b/tests/oauth2/test_oauth2_admin.py
@@ -25,7 +25,7 @@ def test_get_claims(mocker):
         "token": token,
         "iss": kc_settings.kc_realm_url.unicode_string(),
         "audience": kc_settings.auth_client,
-        "options": kc_settings.jwt_opts,
+        "options": kc_settings._jwt_opts,
     }
 
     encoded = jose.jwt.encode(claims=claims, key=mock_key_value, algorithm="HS256")
@@ -35,7 +35,7 @@ def test_get_claims(mocker):
         key=mock_key_value,
         issuer=kc_settings.kc_realm_url.unicode_string(),
         audience=kc_settings.auth_client,
-        options=kc_settings.jwt_opts,
+        options=kc_settings._jwt_opts,
     )
 
     actual_result = oauth2_admin.get_claims(encoded)


### PR DESCRIPTION
closes #20 