### PR TITLE
27 return unauthenticateduser if token is empty

### DIFF
--- a/src/regtech_api_commons/oauth2/oauth2_backend.py
+++ b/src/regtech_api_commons/oauth2/oauth2_backend.py
@@ -25,6 +25,8 @@ class BearerTokenAuthBackend(AuthenticationBackend):
     async def authenticate(self, conn: HTTPConnection) -> Coroutine[Any, Any, Tuple[AuthCredentials, BaseUser] | None]:
         try:
             token = await self.token_bearer(conn)
+            if not token:
+                return AuthCredentials("unauthenticated"), UnauthenticatedUser()
             claims = self.oauth2_admin.get_claims(token)
             if claims is not None:
                 auths = (

--- a/tests/oauth2/test_oauth2_backend.py
+++ b/tests/oauth2/test_oauth2_backend.py
@@ -37,6 +37,21 @@ claims = {
     "resource_access": {"account": {"roles": ["manage-account", "manage-account-links", "view-profile"]}},
 }
 
+@pytest.mark.asyncio
+async def test_empty_token(mocker):
+    mock_token_bearer = mocker.patch("fastapi.security.OAuth2AuthorizationCodeBearer.__call__")
+    mock_token_bearer.return_value = None
+    
+    scope = {
+        "method": "GET",
+        "type": "http",
+        "headers": [("host", "localhost"), ("accept", "application/json")],
+    }
+    
+    response = await bearer_token.authenticate(HTTPConnection(scope=scope))
+    assert response[0].scopes == AuthCredentials("unauthenticated").scopes
+    assert response[1].is_authenticated is False
+    
 
 def test_oauth2_extract_nested_with_correct_keys():
     assert bearer_token.extract_nested(claims, "resource_access", "account", "roles") == [

--- a/tests/oauth2/test_oauth2_backend.py
+++ b/tests/oauth2/test_oauth2_backend.py
@@ -37,21 +37,22 @@ claims = {
     "resource_access": {"account": {"roles": ["manage-account", "manage-account-links", "view-profile"]}},
 }
 
+
 @pytest.mark.asyncio
 async def test_empty_token(mocker):
     mock_token_bearer = mocker.patch("fastapi.security.OAuth2AuthorizationCodeBearer.__call__")
     mock_token_bearer.return_value = None
-    
+
     scope = {
         "method": "GET",
         "type": "http",
         "headers": [("host", "localhost"), ("accept", "application/json")],
     }
-    
+
     response = await bearer_token.authenticate(HTTPConnection(scope=scope))
     assert response[0].scopes == AuthCredentials("unauthenticated").scopes
     assert response[1].is_authenticated is False
-    
+
 
 def test_oauth2_extract_nested_with_correct_keys():
     assert bearer_token.extract_nested(claims, "resource_access", "account", "roles") == [


### PR DESCRIPTION
Closes #27 

The parsing of the token bearer was throwing a runtime error, which was eventually causing a 500 server error, if the Bearer token in the request was null/None.    This fixes that to return 'unauthenticated'