### PR TITLE
Added check for authorization header

### DIFF
--- a/tests/oauth2/test_oauth2_backend.py
+++ b/tests/oauth2/test_oauth2_backend.py
@@ -46,7 +46,7 @@ async def test_empty_token(mocker):
     scope = {
         "method": "GET",
         "type": "http",
-        "headers": [("host", "localhost"), ("accept", "application/json")],
+        "headers": [(b"host", b"localhost"), (b"accept", b"application/json"), (b"authorization", b"")],
     }
 
     response = await bearer_token.authenticate(HTTPConnection(scope=scope))
@@ -82,7 +82,7 @@ async def test_oauth2_authenticate_with_claims(mocker):
     scope = {
         "method": "GET",
         "type": "http",
-        "headers": [("host", "localhost"), ("accept", "application/json")],
+        "headers": [(b"host", b"localhost"), (b"accept", b"application/json"), (b"authorization", b"test")],
     }
 
     response = await bearer_token.authenticate(HTTPConnection(scope=scope))
@@ -99,7 +99,7 @@ async def test_oauth2_authenticate_without_claims(mocker):
     scope = {
         "method": "GET",
         "type": "http",
-        "headers": [("host", "localhost"), ("accept", "application/json")],
+        "headers": [(b"host", b"localhost"), (b"accept", b"application/json")],
     }
 
     response = await bearer_token.authenticate(HTTPConnection(scope=scope))


### PR DESCRIPTION
Closes #33 

The issue was the `token_bearer.__call__` function throws an HTTPException, which we were catching and logging, if there is no "Authorization" header in the request.  To avoid this, but still keep potential other unexpected error conditions logged, I added a check for the authorization header in the request as the first thing.  If it doesn't exist, we return unauthenticated (like you'd expect).  This will keep api's that use this library on /docs checks from spamming the logs with error entries.

The reason THAT was happening is because the FastAPI middlewares are called prior to request processing by the endpoint.  This means any request being sent to the server will go through the middleware.  Since the logging was happening in the middleware, it was spitting out the error even though the /docs endpoint isn't required to be authenticated.