### PR TITLE
Fixing get_group_by_path response

### DIFF
--- a/src/regtech_api_commons/oauth2/oauth2_admin.py
+++ b/src/regtech_api_commons/oauth2/oauth2_admin.py
@@ -82,7 +82,7 @@ class OAuth2Admin:
     def get_group(self, lei: str) -> Dict[str, Any] | None:
         try:
             group = self._admin.get_group_by_path(f"/{lei}")
-            if "error" not in group:
+            if group and "error" not in group:
                 return group
             else:
                 log.error(f"Results from get_group_by_path: {group}")

--- a/src/regtech_api_commons/oauth2/oauth2_admin.py
+++ b/src/regtech_api_commons/oauth2/oauth2_admin.py
@@ -81,7 +81,12 @@ class OAuth2Admin:
 
     def get_group(self, lei: str) -> Dict[str, Any] | None:
         try:
-            return self._admin.get_group_by_path(f"/{lei}")
+            group = self._admin.get_group_by_path(f"/{lei}")
+            if "error" not in group:
+                return group
+            else:
+                log.error(f"Results from get_group_by_path: {group}")
+                return None
         except kce.KeycloakError:
             return None
 

--- a/src/regtech_api_commons/oauth2/oauth2_admin.py
+++ b/src/regtech_api_commons/oauth2/oauth2_admin.py
@@ -82,10 +82,10 @@ class OAuth2Admin:
     def get_group(self, lei: str) -> Dict[str, Any] | None:
         try:
             group = self._admin.get_group_by_path(f"/{lei}")
-            if group and "error" not in group:
+            if group and "id" in group:
                 return group
             else:
-                log.error(f"Results from get_group_by_path: {group}")
+                log.error(f"Unexpected results from get_group_by_path: {group}")
                 return None
         except kce.KeycloakError:
             return None

--- a/tests/oauth2/test_oauth2_admin.py
+++ b/tests/oauth2/test_oauth2_admin.py
@@ -106,6 +106,12 @@ def test_upsert_group_new(mocker: MockerFixture):
     result = oauth2_admin.upsert_group(lei=lei, name=name)
     assert result == lei
 
+    mock_get_group = mocker.patch("keycloak.KeycloakAdmin.get_group_by_path")
+    mock_get_group.return_value = {"error": "Group path does not exist"}
+
+    result = oauth2_admin.upsert_group(lei=lei, name=name)
+    assert result == lei
+
 
 def test_upsert_group_existing(mocker: MockerFixture):
     lei = "TESTLEI"


### PR DESCRIPTION
Closes #178 

I added a log.error message just in case there are other errors that might come out of this and we don't just assume an "error" key means the group exists.  I was looking in the source and it appears there should be some function that actually treats an error object from the response as an exception but that's definitely not what the code is doing.  So left in the original exception catch if that gets fixed again at some point.

Also thought about checking for "id" in the group instead of "error" not in.  That might be preferred since we use the group["id"] later.  'just in case' the source is returning some other json besides the 'error' that we're not expecting (but can't really tell since that code gets into keycloak responses)